### PR TITLE
Recalculate local position on each update fixes #4

### DIFF
--- a/Source/CNControls/Scripts/CNAbstractController.cs
+++ b/Source/CNControls/Scripts/CNAbstractController.cs
@@ -205,6 +205,9 @@ public abstract class CNAbstractController : MonoBehaviour
 
     protected virtual void Update()
     {
+        // Recalculate position always
+        TransformCache.localPosition = InitializePosition();
+        
         // Check for touches
         if (TweakIfNeeded())
             return;


### PR DESCRIPTION
Recalculate local position always so that the CollisionRect will always be waiting for input around the BaseObject.